### PR TITLE
fix(PL-2701): give user permission to home for storing helm cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ COPY --from=build --chown=golang:root /app/joy-generator /app/
 
 RUN apk add helm
 
+RUN mkdir -p /home/golang && chown -R golang:root /home/golang
+
 USER golang:root
 EXPOSE 8080
 


### PR DESCRIPTION
Attempting to fix:

```
│ failed to authenticate to helm: exit status 1: "Error: mkdir /home/golang: permission denied\n"                                                                                                                                                
```