### PR TITLE
fix(PL-2763): do not pull charts concurrently

### DIFF
--- a/cmd/server/api_get_params_test.go
+++ b/cmd/server/api_get_params_test.go
@@ -69,7 +69,7 @@ func TestGetParamsE2E(t *testing.T) {
 			CacheRoot:      cacheDir,
 			LoadJoyContext: generator.RepoLoader(repo),
 			Logger:         logger,
-			ChartPuller:    generator.ChartPuller{Logger: logger},
+			ChartPuller:    generator.MakeChartPuller(logger),
 		},
 	})
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -71,7 +71,7 @@ func run() error {
 				CacheRoot:      cfg.CacheRoot,
 				LoadJoyContext: generator.RepoLoader(repo),
 				Logger:         logger,
-				ChartPuller:    generator.ChartPuller{Logger: logger},
+				ChartPuller:    generator.MakeChartPuller(logger),
 			},
 		}),
 		ReadHeaderTimeout: 5 * time.Second,


### PR DESCRIPTION
Fixing errors when generator concurrently pulls the same chart

<img width="768" alt="image" src="https://github.com/nestoca/joy-generator/assets/12768642/a2916dc6-417f-4ad3-9539-7eca0a4d83ce">
