### PR TITLE
fix(PL-2763): check cache folder is empty before pulling

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -61,11 +61,11 @@ func (puller ChartPuller) Pull(ctx context.Context, opts helm.PullOptions) error
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	if _, err := os.Stat(opts.OutputDir); err == nil {
-		// If output directory exists it has been pulled by another goroutine
-		// No need to pull the chart
+	if entries, err := os.ReadDir(opts.OutputDir); err == nil && len(entries) > 0 {
+		// If output directory exists and has content in it,
+		// then it has been pulled by another goroutine: no need to pull the chart
 		return nil
-	} else if !errors.Is(err, os.ErrNotExist) {
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to stat chart cache: %w", err)
 	}
 


### PR DESCRIPTION
Turns out that joy prepares the output directory and creates it before attempting to pull. Therefore it is not sufficient to check the existence of the cache directory, but we must instead check if the cache directory has content in it.