### PR TITLE
feat(PL-2806): make joy-generator requestTimeout configurable

### DIFF
--- a/chart/templates/argocd-config.yaml
+++ b/chart/templates/argocd-config.yaml
@@ -5,3 +5,4 @@ metadata:
 data:
   token: "${{ include "joy-generator.fullname" . }}-config:PLUGIN_TOKEN"
   baseUrl: "http://{{ include "joy-generator.fullname" . }}"
+  requestTimeout: "{{ .Values.requestTimeout }}"

--- a/chart/tests/with-additional-labels/expected.yaml
+++ b/chart/tests/with-additional-labels/expected.yaml
@@ -24,6 +24,7 @@ metadata:
 data:
   token: "$my-release-joy-generator-config:PLUGIN_TOKEN"
   baseUrl: "http://my-release-joy-generator"
+  requestTimeout: "30"
 ---
 # Source: joy-generator/templates/service.yaml
 apiVersion: v1

--- a/chart/tests/with-credentials/expected.yaml
+++ b/chart/tests/with-credentials/expected.yaml
@@ -16,6 +16,7 @@ metadata:
 data:
   token: "$my-release-joy-generator-config:PLUGIN_TOKEN"
   baseUrl: "http://my-release-joy-generator"
+  requestTimeout: "30"
 ---
 # Source: joy-generator/templates/service.yaml
 apiVersion: v1

--- a/chart/tests/with-github-app/expected.yaml
+++ b/chart/tests/with-github-app/expected.yaml
@@ -24,6 +24,7 @@ metadata:
 data:
   token: "$my-release-joy-generator-config:PLUGIN_TOKEN"
   baseUrl: "http://my-release-joy-generator"
+  requestTimeout: "30"
 ---
 # Source: joy-generator/templates/service.yaml
 apiVersion: v1

--- a/chart/tests/with-github-token/expected.yaml
+++ b/chart/tests/with-github-token/expected.yaml
@@ -16,6 +16,7 @@ metadata:
 data:
   token: "$my-release-joy-generator-config:PLUGIN_TOKEN"
   baseUrl: "http://my-release-joy-generator"
+  requestTimeout: "30"
 ---
 # Source: joy-generator/templates/service.yaml
 apiVersion: v1

--- a/chart/tests/with-request-timeout/expected.yaml
+++ b/chart/tests/with-request-timeout/expected.yaml
@@ -1,4 +1,13 @@
 ---
+# Source: joy-generator/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-release-joy-generator-config
+stringData:
+  GH_TOKEN: "12312312312312"
+  PLUGIN_TOKEN: '@very!l0ngands3curet0ken'
+---
 # Source: joy-generator/templates/argocd-config.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7,7 +16,7 @@ metadata:
 data:
   token: "$my-release-joy-generator-config:PLUGIN_TOKEN"
   baseUrl: "http://my-release-joy-generator"
-  requestTimeout: "30"
+  requestTimeout: "420"
 ---
 # Source: joy-generator/templates/service.yaml
 apiVersion: v1
@@ -59,9 +68,12 @@ spec:
       volumes:
         - name: catalog-dir
           emptyDir: {}
-        - name: github-app-private-key
+        - name: credentials
           secret:
-            secretName: my-release-joy-generator-github-app-key
+            secretName: super-secret
+            items:
+              - key: street-creds
+                path: credentials.json
       containers:
         - name: joy-generator
           securityContext:
@@ -71,23 +83,22 @@ spec:
           volumeMounts:
             - mountPath: /tmp/catalog
               name: catalog-dir
-            - mountPath: /etc/joy/config
-              name: github-app-private-key
+            - mountPath: /etc/joy/secrets
+              name: credentials
+              readOnly: true
           env:
             - name: CATALOG_DIR
               value: "/tmp/catalog"
             - name: CATALOG_URL
               value: "https://github.com/example/foobar.git"
-            - name: GH_APP_ID
-              value: "123456"
-            - name: GH_APP_INSTALLATION_ID
-              value: "789101112"
+            - name: GH_USER
+              value: "username"
             - name: GRACE_PERIOD
               value: "10s"
             - name: PORT
               value: ":8080"
-            - name: GH_APP_PRIVATE_KEY_PATH
-              value: /etc/joy/config/githubApp.pem
+            - name: CREDENTIALS_FILE
+              value: /etc/joy/secrets/credentials.json
           envFrom:
             - secretRef:
                 name: my-release-joy-generator-config
@@ -105,26 +116,3 @@ spec:
               port: http
           resources:
             {}
----
-# Source: joy-generator/templates/secret.yaml
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: my-release-joy-generator-config
-  annotations:
-    sealedsecrets.bitnami.com/cluster-wide: "true"
-spec:
-  encryptedData:
-    PLUGIN_TOKEN: '@very!l0ngands3curet0ken'
----
-# Source: joy-generator/templates/secret.yaml
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: my-release-joy-generator-github-app-key
-  annotations:
-    sealedsecrets.bitnami.com/cluster-wide: "true"
-spec:
-  encryptedData:
-    githubApp.pem: |
-      FOOBARLOREMISPUM

--- a/chart/tests/with-request-timeout/values.yaml
+++ b/chart/tests/with-request-timeout/values.yaml
@@ -1,0 +1,17 @@
+requestTimeout: 420
+
+env:
+  CATALOG_URL: https://github.com/example/foobar.git
+  GH_USER: username
+
+secretEnv:
+  values:
+    PLUGIN_TOKEN: "@very!l0ngands3curet0ken"
+    GH_TOKEN: "12312312312312"
+
+image:
+  tag: 0.1.2
+
+credentialsSecret:
+  name: super-secret
+  key: street-creds

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -26,6 +26,9 @@ sealedSecretAnnotations: {}
 
 replicaCount: 1
 
+# Configure the timeout when calling this plugin from the applicationset controller
+requestTimeout: 30
+
 image:
   repository: ghcr.io/nestoca/joy-generator
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Motivation
Currently many of our appset requests are timing out with Client.Timeout errors. This is because our plugin needs to pull from various external sources such as github and GAR. Sometimes it does not meet the plugins timeout configuration.
Therefore we want to be able to extend it.

## Solution
ArgoCD allows you to configure the requestTimeout when calling a plugin via its configmap configuration.

https://github.com/argoproj/argo-cd/blob/9347d8d587bfc83fcf0863d756d1a37c100d72ea/applicationset/generators/plugin.go#L99-L112

This PR utilizes this feature and allows us to configure our generator with this value.