### PR TITLE
feat(PL-2911): configure health probe timeouts

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -88,10 +88,12 @@ spec:
             httpGet:
               path: /api/v1/health
               port: http
+            timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
           readinessProbe:
             httpGet:
               path: /api/v1/readiness
               port: http
+            timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/chart/tests/with-additional-labels/expected.yaml
+++ b/chart/tests/with-additional-labels/expected.yaml
@@ -117,9 +117,11 @@ spec:
             httpGet:
               path: /api/v1/health
               port: http
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /api/v1/readiness
               port: http
+            timeoutSeconds: 1
           resources:
             {}

--- a/chart/tests/with-credentials/expected.yaml
+++ b/chart/tests/with-credentials/expected.yaml
@@ -110,9 +110,11 @@ spec:
             httpGet:
               path: /api/v1/health
               port: http
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /api/v1/readiness
               port: http
+            timeoutSeconds: 1
           resources:
             {}

--- a/chart/tests/with-github-app-and-sealed-secrets/expected.yaml
+++ b/chart/tests/with-github-app-and-sealed-secrets/expected.yaml
@@ -99,10 +99,12 @@ spec:
             httpGet:
               path: /api/v1/health
               port: http
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /api/v1/readiness
               port: http
+            timeoutSeconds: 1
           resources:
             {}
 ---

--- a/chart/tests/with-github-app/expected.yaml
+++ b/chart/tests/with-github-app/expected.yaml
@@ -116,9 +116,11 @@ spec:
             httpGet:
               path: /api/v1/health
               port: http
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /api/v1/readiness
               port: http
+            timeoutSeconds: 1
           resources:
             {}

--- a/chart/tests/with-github-token/expected.yaml
+++ b/chart/tests/with-github-token/expected.yaml
@@ -99,9 +99,11 @@ spec:
             httpGet:
               path: /api/v1/health
               port: http
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /api/v1/readiness
               port: http
+            timeoutSeconds: 1
           resources:
             {}

--- a/chart/tests/with-request-timeout/expected.yaml
+++ b/chart/tests/with-request-timeout/expected.yaml
@@ -110,9 +110,11 @@ spec:
             httpGet:
               path: /api/v1/health
               port: http
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /api/v1/readiness
               port: http
+            timeoutSeconds: 1
           resources:
             {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,7 +19,7 @@ secretEnv:
     # PLUGIN_TOKEN: ""
     # GH_TOKEN: ""
 
-githubAppPrivateKey: ""
+githubAppPrivateKey: ''
 
 # Additional annotations for sealed secrets
 sealedSecretAnnotations: {}
@@ -33,11 +33,14 @@ image:
   repository: ghcr.io/nestoca/joy-generator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: ''
+
+probes:
+  timeoutSeconds: 1
 
 imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
+nameOverride: ''
+fullnameOverride: ''
 
 podAnnotations: {}
 


### PR DESCRIPTION
## Goal

Allow us to increase the timeoutSeconds property for our health probes.

## Why

The joy-generator is more context-aware than before in recent updates. This has allowed us to notice that our readiness checks are timing out in a semi-regular manner. We therefore need to increase the timeout to something more appropriate than 1 second since we are connecting to the github api.