### PR TITLE
fix(PL-3219): update (deprecated) actions/upload-pages-artifact to v4

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Upload pages artifact
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ${{ runner.temp }}/helm-release
 

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Upload pages artifact
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ${{ runner.temp }}/helm-release
 


### PR DESCRIPTION
Addresses [failed build](https://github.com/nestoca/joy-generator/actions/runs/14268153041/job/39995682515) due to calls to `actions/upload-artifact@v3`; Downstream use by `actions/upload-pages-artifact@v2`

Ref: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/