### PR TITLE
feat(PL-3383): add trace specifically for ComputeReleaseValues

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -200,7 +200,10 @@ func (generator *Generator) Run(ctx context.Context) ([]Result, error) {
 			release.Spec.Chart.Name = chart.Name
 			release.Spec.Chart.Version = chart.Version
 
+			ctx, computeSpan := observability.StartTrace(ctx, "compute_release_values")
 			values, err := joy.ComputeReleaseValues(release, chart)
+			computeSpan.End()
+
 			if err != nil {
 				generator.Logger.
 					Error().


### PR DESCRIPTION
Technically, we also care about the amount of time it takes to load that chart, but we can infer that from the difference between `release_render` and `compute_release_values`.