### PR TITLE
feat(PL-3383): tweak traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ArgoCD plugin for expanding joy releases for the ArgoCD ApplicationSet Controlle
 
 ## Data Flow
 
-ArgoCD's ApplicationSet controller will queries `joy-generator` on Webhooks or schedule. The latter returns a full list of parameters for each application in the catalog. The ApplicationSet controller will then create or update the Application resources in the cluster. See [Argo CD - Generators
+Argo CD's ApplicationSet controller will query `joy-generator` on Webhooks or schedule. The latter returns a full list of parameters for each application in the catalog. The ApplicationSet controller will then create or update the Application resources in the cluster. See [Argo CD - Generators
 Plugin](https://argo-cd.readthedocs.io/en/latest/operator-manual/applicationset/Generators-Plugin/) for more information.
 
 ```mermaid

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -36,6 +36,8 @@ func run() (err error) {
 
 	cfg := GetConfig()
 
+	logger.Info().Msgf("starting in %s with %d concurrency", cfg.Environment, cfg.Generator.Concurrency)
+
 	teardown, err := observability.SetupTracer(observability.TracerOptions{
 		OTLPEndpoint:   cfg.Otel.Address,
 		Environment:    cfg.Environment,

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -174,6 +174,7 @@ func (generator *Generator) Run(ctx context.Context) ([]Result, error) {
 
 			ctx, span := observability.StartTrace(ctx, "release_render")
 			defer span.End()
+			span.SetAttributes(attribute.String("release", release.Name))
 
 			span.SetAttributes(
 				attribute.String("release", release.Name),
@@ -200,10 +201,7 @@ func (generator *Generator) Run(ctx context.Context) ([]Result, error) {
 			release.Spec.Chart.Name = chart.Name
 			release.Spec.Chart.Version = chart.Version
 
-			ctx, computeSpan := observability.StartTrace(ctx, "compute_release_values")
 			values, err := joy.ComputeReleaseValues(release, chart)
-			computeSpan.End()
-
 			if err != nil {
 				generator.Logger.
 					Error().


### PR DESCRIPTION

`release_render` and `compute_release_values` where or less the same.

Added the release name to the trace to see if some releases are slower than others.

Also logging the concurrency at boot time.

feat(PL-3383): docs, add data flow seq