### PR TITLE
fix(PL-5360): add LOG_LEVEL env var to configure log level

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Port        string
 	GracePeriod time.Duration
 	Environment string
+	LogLevel    string
 
 	PluginToken string
 
@@ -53,6 +54,7 @@ func GetConfig() Config {
 	}
 
 	conf.Var(conf.Environ, &cfg.CacheRoot, "CACHE_ROOT", conf.Default(filepath.Join(home, ".cache", "joy")))
+	conf.Var(conf.Environ, &cfg.LogLevel, "LOG_LEVEL", conf.Default("info"))
 	conf.Var(conf.Environ, &cfg.Port, "PORT", conf.Default(":8080"))
 	conf.Var(conf.Environ, &cfg.Environment, "ENVIRONMENT", conf.Default("local"))
 	conf.Var(conf.Environ, &cfg.GracePeriod, "GRACE_PERIOD", conf.Default(10*time.Second))

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -33,9 +33,14 @@ func main() {
 }
 
 func run() (err error) {
-	logger := zerolog.New(os.Stdout)
-
 	cfg := GetConfig()
+
+	level, err := zerolog.ParseLevel(cfg.LogLevel)
+	if err != nil {
+		return fmt.Errorf("invalid LOG_LEVEL %q: %w", cfg.LogLevel, err)
+	}
+
+	logger := zerolog.New(os.Stdout).Level(level)
 
 	logger.Info().Msgf("starting in %s with %d concurrency", cfg.Environment, cfg.Generator.Concurrency)
 


### PR DESCRIPTION
## Summary
- Adds `LOG_LEVEL` environment variable to control the zerolog log level at runtime
- Defaults to `info` if not set
- Returns a startup error if an invalid value is provided

Valid values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`, `disabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)