### PR TITLE
fix(PL-5745): prevent workflow injection via github.head_ref

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -52,8 +52,9 @@ jobs:
       - name: Dispatch workflow
         env:
           GH_TOKEN: ${{ steps.generate-joy-ci-triggerer-token.outputs.token }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          gh workflow run --repo github.com/nestoca/catalog -f ref=${{ github.head_ref }} .github/workflows/joy-generator-test.yaml
+          gh workflow run --repo github.com/nestoca/catalog -f ref="$HEAD_REF" .github/workflows/joy-generator-test.yaml
           sleep 5s
           workflowId=$(gh run ls --repo github.com/nestoca/catalog --workflow joy-generator-test --json databaseId -q '.[0].databaseId')
           gh run watch --exit-status --repo github.com/nestoca/catalog $workflowId
@@ -123,7 +124,7 @@ jobs:
 
       - name: Generate changelog and tag release
         id: changelog
-        uses: nestoca/conventional-changelog-action@releases/v5
+        uses: nestoca/conventional-changelog-action@633dae602dcd3203777969e935995deb7d9d832f # releases/v5
         with:
           input-file: CHANGELOG.md
           output-file: CHANGELOG.md


### PR DESCRIPTION
## What

- Fix script injection: move `github.head_ref` out of inline script interpolation into an env var (`HEAD_REF`)
- Quote the env var usage (`"$HEAD_REF"`) to prevent word splitting
- Pin `nestoca/conventional-changelog-action` to a commit SHA instead of a mutable branch ref (`releases/v5`)

## Why
Two findings from `poutine analyze_local .`:
- **warning** `injection`: `${{ github.head_ref }}` was interpolated directly into a shell script, allowing a malicious branch name to inject arbitrary shell commands
- **note** `github_action_from_unverified_creator_used`: action was pinned to a mutable branch ref; SHA pinning reduces supply chain risk

## How
Fixed with Claude Code

- `poutine analyze_local .` → identified findings → applied fixes → verified clean run for the injection finding

## Test Plan
- [x] Run `poutine analyze_local .` — injection finding is resolved
- [ ] Confirm the `publish` job still works on merge to master (changelog action pinned to same commit it was previously tracking)