### PR TITLE
chore: add gitIgnoredAuthors to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,8 @@
 {
+  "gitIgnoredAuthors": [
+    "41898282+github-actions[bot]@users.noreply.github.com",
+    "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+  ],
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

- Adds `gitIgnoredAuthors` to `renovate.json` so Renovate continues to auto-rebase PRs after commits from `github-actions[bot]`
- Without this, Renovate posts an "Edited/Blocked" warning and stops rebasing, requiring manual intervention

## Jira

[PL-6031](https://nestoca.atlassian.net/browse/PL-6031)

## Reference

Pattern established in nestoca/jen#174

[PL-6031]: https://nestoca.atlassian.net/browse/PL-6031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Renovate behavior; no application runtime, auth, or data paths affected.
> 
> **Overview**
> Adds **`gitIgnoredAuthors`** to `renovate.json` with the two standard **`github-actions[bot]`** identity strings (numeric GitHub noreply email and display-name form).
> 
> Renovate will treat commits from that bot as non-blocking so it keeps **auto-rebasing** dependency PRs after CI or other Actions push to the branch, instead of stopping with an **Edited/Blocked** state that needs manual fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e5e43d9845f1dd1edc5f39921bfdf4aea4986a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->