### PR TITLE
chore(PL-5995): bump Go toolchain to go1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nestoca/joy-generator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.11.0


### PR DESCRIPTION
## Summary
- Bump Go toolchain to 1.26.4 to resolve recently discovered stdlib CVEs published 2026-06-03:
  - [`std/crypto/x509`](https://security.snyk.io/vuln/SNYK-GOLANG-STDCRYPTOX509-17135840) — High
  - [`std/mime`](https://security.snyk.io/vuln/SNYK-GOLANG-STDMIME-17135844) — High
  - [`std/net/textproto`](https://security.snyk.io/vuln/SNYK-GOLANG-STDNETTEXTPROTO-17135843) — Medium

Closes PL-5995, PL-5996

## Test plan
- [ ] `GOTOOLCHAIN=go1.26.4 snyk test --all-projects` returns no vulnerable paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line toolchain bump with no code or dependency changes; low risk aside from ensuring CI/local builds use Go 1.26.4.
> 
> **Overview**
> Updates the module’s declared Go version in **`go.mod`** from **1.26.3** to **1.26.4** so builds use a patched standard library (addressing recent **High/Medium** CVEs in `crypto/x509`, `mime`, and `net/textproto`).
> 
> No application source or dependency version changes in this diff—only the toolchain directive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa63665aa39f321a46c0c306abeefa5d276fb6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->