### PR TITLE
fix(PL-6101): use upstream TriPSs/conventional-changelog-action

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Generate changelog and tag release
         id: changelog
-        uses: nestoca/conventional-changelog-action@633dae602dcd3203777969e935995deb7d9d832f # releases/v5
+        uses: TriPSs/conventional-changelog-action@3c4970b6573374889b897403d2f1278c395ea0df # releases/v5
         with:
           input-file: CHANGELOG.md
           output-file: CHANGELOG.md


### PR DESCRIPTION
## What

Switch from `nestoca/conventional-changelog-action` to `TriPSs/conventional-changelog-action@3c4970b6 # releases/v5` (upstream).

## Why

Maintaining the nestoca fork is unnecessary overhead. Pinning an action to a specific upstream commit SHA gives the same supply-chain guarantee as maintaining a fork — making the fork unnecessary. We're dropping the fork in favour of pinning directly to the upstream release branch.

## References

- [PL-6101](https://nestoca.atlassian.net/browse/PL-6101) — Switch back to TriPSs/conventional-changelog-action from nestoca fork
- [PL-5691](https://nestoca.atlassian.net/browse/PL-5691) — Original Snyk/security ticket
- Slack: https://nestomortgage.slack.com/archives/C02RCBVTJ3G/p1780940095066939

[PL-6101]: https://nestoca.atlassian.net/browse/PL-6101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PL-5691]: https://nestoca.atlassian.net/browse/PL-5691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the master publish path that derives versions, tags, and release notes; any behavioral difference in the upstream action could affect releases even though inputs are unchanged.
> 
> **Overview**
> The **Build & Publish** workflow’s **Generate changelog and tag release** step now uses **`TriPSs/conventional-changelog-action`** at commit **`3c4970b6`** (`releases/v5`) instead of the **`nestoca/conventional-changelog-action`** fork at a different SHA.
> 
> Step **`id`**, inputs (`CHANGELOG.md`, `fallback-version`, skip flags), and downstream uses of **`steps.changelog.outputs`** (chart version bumps, release tag/body) are unchanged—only the action source is swapped while keeping a fixed commit pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45e556f80146cb63890b8d59a8a02509bcecef84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->