### PR TITLE
feat(PL-6287): update to latest joy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect; security update
-	github.com/nestoca/joy v0.90.1
+	github.com/nestoca/joy v0.92.0
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
@@ -23,7 +23,10 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require google.golang.org/grpc v1.81.1
+require (
+	google.golang.org/grpc v1.81.1
+	k8s.io/apimachinery v0.36.1
+)
 
 require (
 	cuelang.org/go v0.15.4 // indirect
@@ -118,7 +121,6 @@ require (
 	gopkg.in/godo.v2 v2.0.9 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	k8s.io/apimachinery v0.36.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/nestoca/joy v0.90.1 h1:30V1JeF7fQw3pQ6NRlpvjIra3U0eRDCB/0Bs9nM4w8I=
-github.com/nestoca/joy v0.90.1/go.mod h1:daMJaOYyGCONHO5ORCh20gcxUYQ8pi8kuy4zIgcgaLc=
+github.com/nestoca/joy v0.92.0 h1:m5UrRUcY4I1KnJjvXZzy281l5g8hm8QNaTILwbH/Uq0=
+github.com/nestoca/joy v0.92.0/go.mod h1:daMJaOYyGCONHO5ORCh20gcxUYQ8pi8kuy4zIgcgaLc=
 github.com/nestoca/survey/v2 v2.0.0 h1:orM/TXtBSQJCPiZy9N51hcwH0WzFjQJ7TQKCfMTnGoQ=
 github.com/nestoca/survey/v2 v2.0.0/go.mod h1:QfmcQfCRtqsiBpePFhHEW0MY9QH7lSpw3CQinsdC/dc=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=


### PR DESCRIPTION
## Summary
- Update `github.com/nestoca/joy` dependency to `v0.92.0`


## Test plan
- [ ] Verify `go mod tidy` / build passes
- [ ] Run relevant CI checks

Related: PL-6287

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the Joy dependency to a newer version.
  * Promoted a Kubernetes API dependency to a direct application dependency.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->