### PR TITLE
fix: invalidate value cache on catalog.yaml change

### DIFF
--- a/internal/generator/valuecache.go
+++ b/internal/generator/valuecache.go
@@ -110,8 +110,11 @@ func (vc *valueCache) CleanupCache() error {
 	vc.logger.Info().Strs("changedFiles", changedFiles).Str("previousRef", vc.previousRef).Str("currentRef", currentRef).Msg("Change detected in git repository")
 
 	for _, file := range changedFiles {
-		if file == "joy.yaml" {
-			vc.logger.Info().Msg("joy.yaml changed, clearing all cache")
+		// joy.yaml and catalog.yaml both hold repo-wide config (catalog.yaml carries the
+		// chart refs/versions), so a change to either can affect every release's computed
+		// values and must invalidate the whole cache.
+		if file == "joy.yaml" || file == "catalog.yaml" {
+			vc.logger.Info().Str("file", file).Msg("repo-wide config changed, clearing all cache")
 			vc.environments = make(map[string]struct {
 				releases map[string]string
 			})

--- a/internal/generator/valuecache_test.go
+++ b/internal/generator/valuecache_test.go
@@ -34,6 +34,12 @@ func TestCleanupCache(t *testing.T) {
 			expectedSize: 0,
 		},
 		{
+			name:         "catalog.yaml cache cleanup",
+			cachedFiles:  cachedFiles,
+			changedFiles: []string{"catalog.yaml"},
+			expectedSize: 0,
+		},
+		{
 			name:         "env cache cleanup",
 			cachedFiles:  cachedFiles,
 			changedFiles: []string{"environments/staging/env.yaml"},


### PR DESCRIPTION
## What

> [!IMPORTANT]
> This fixes a critical cache invalidation bug introduced by joy-generator `v0.35.0`

`CleanupCache` now clears the entire value cache when `catalog.yaml` changes.

## Why

Chart refs and versions are configured in `catalog.yaml`. Previously the value cache was only fully invalidated on a `joy.yaml` change, so a change to `catalog.yaml` (e.g. a chart version bump) left every unchanged release's values cached against the previously resolved chart. Those stale values could then be rendered against a newly resolved chart, producing incorrect or failing output.

## How

- Treat `catalog.yaml` like `joy.yaml` in `internal/generator/valuecache.go`: a change to either wipes the whole cache.
- Add a `TestCleanupCache` case asserting a `catalog.yaml` change clears the cache.

## Post-merge

- [ ] After merging, I suggest retracting the [`v0.35.0` release](https://github.com/nestoca/joy-generator/releases/tag/v0.35.0) by marking it as "pre-release".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cache invalidation to recognize changes to both `joy.yaml` and `catalog.yaml`.
  * Ensures repository-wide configuration changes reliably refresh cached results.

* **Tests**
  * Added coverage verifying that changes to `catalog.yaml` clear the cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->