### PR TITLE
feat(pL-6299): update joy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/davidmdm/x/xerr v0.0.6
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-git/go-git/v5 v5.19.1
-	github.com/nestoca/joy v0.95.1
+	github.com/nestoca/joy v0.96.0
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
@@ -128,4 +128,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
+	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/nestoca/joy v0.95.1 h1:PIcW5A0XXXuqE22cd6T3mguGCusp99TA15wN5OPwfE4=
-github.com/nestoca/joy v0.95.1/go.mod h1:daMJaOYyGCONHO5ORCh20gcxUYQ8pi8kuy4zIgcgaLc=
+github.com/nestoca/joy v0.96.0 h1:KQmNZO3YkL2oFRTVsjhUMPT3zg74JvPYDkIsa4T07FM=
+github.com/nestoca/joy v0.96.0/go.mod h1:IJYR2DdFyEqg6bmLY3v2STv1iEsGjnTrUTYIp+w5yb8=
 github.com/nestoca/survey/v2 v2.0.0 h1:orM/TXtBSQJCPiZy9N51hcwH0WzFjQJ7TQKCfMTnGoQ=
 github.com/nestoca/survey/v2 v2.0.0/go.mod h1:QfmcQfCRtqsiBpePFhHEW0MY9QH7lSpw3CQinsdC/dc=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> A minor joy bump can change catalog parsing, Helm chart handling, or release parameter generation without local code edits; validate generator output and any joy-related tests after upgrade.
> 
> **Overview**
> Bumps the **`github.com/nestoca/joy`** dependency from **v0.95.1** to **v0.96.0** in `go.mod` and `go.sum`. No application source files change in this PR; behavior shifts only through what the generator already imports from joy (`pkg`, `pkg/catalog`, `pkg/helm`, `api/v1alpha1`).
> 
> The module refresh also records **`sigs.k8s.io/yaml v1.6.0`** as a new indirect dependency, consistent with joy’s updated dependency graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61300c57ac7f63a3a89dbe4161ff4ea1d468ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying project dependency to a newer version.
  * Added support for YAML processing through an indirect dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->